### PR TITLE
Fix TargetSubtargetInfo

### DIFF
--- a/llvm/lib/Target/H2BLB/CMakeLists.txt
+++ b/llvm/lib/Target/H2BLB/CMakeLists.txt
@@ -13,6 +13,7 @@ add_llvm_target(H2BLBCodeGen
   Core
   Support
   Target
+  SelectionDAG
 
   ADD_TO_COMPONENT
   H2BLB

--- a/llvm/lib/Target/H2BLB/H2BLBSubtarget.cpp
+++ b/llvm/lib/Target/H2BLB/H2BLBSubtarget.cpp
@@ -19,7 +19,8 @@ void H2BLBSubtarget::anchor() {}
 
 H2BLBSubtarget::H2BLBSubtarget(const Triple &TT, StringRef CPU, StringRef FS,
                                const TargetMachine &TM)
-    : TargetSubtargetInfo(TT, CPU, /*TuneCPU=*/"", FS, /*PF=*/{},
+  : TargetSubtargetInfo(TT, CPU, /*TuneCPU=*/"", FS, /*PN=*/{},
+                          /*PF=*/{},
                           /*PD=*/{},
                           /*WPR=*/nullptr,
                           /*WL=*/nullptr,


### PR DESCRIPTION
In b6c22a4e the PN field was added to TargetSubtargetInfo, but this was probably not noticed in a rebase of the book's codebase. This adds a placeholder for this. Additionally, I've added SelectionDAG to the link components for this target -- this appears to be necessary for me to get the build to work.